### PR TITLE
Added the minVersion tag and fixes #9

### DIFF
--- a/src/main/resources/flatbedrock.mixins.json
+++ b/src/main/resources/flatbedrock.mixins.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "com.sunekaer.mods.flatbedrock.mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "flatbedrock.refmap.json",


### PR DESCRIPTION
To fix this error and to fix #9 
```
[main/ERROR]: Mixin config flatbedrock.mixins.json does not specify "minVersion" property
```